### PR TITLE
i18n: localise Wikipedia links to match active UI language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
-- **Content localisation** — added 4 i18next namespaces (`composers`, `compositions`, `events`, `eras`) for content data alongside the existing `translation` namespace for UI strings. Data hooks in `src/hooks/useData.ts` now merge base JSON with namespace translations via `useTranslation()` + `useMemo`. Full French (fr-FR) and Afrikaans (af-ZA) content translations for all 51 composers, 196 compositions, 47 events, and 6 eras.
+- **Wikipedia link localisation** — all "Read on Wikipedia" links (ComposerCard, CompositionDetail, EventMarker) and the WikipediaService API calls now use the Wikipedia subdomain matching the current i18n language (e.g. `fr.wikipedia.org` when the UI is set to French). Centralised in `src/utils/wikipedia.ts`.
+
+- **Content localisation** — added 4 i18next namespaces(`composers`, `compositions`, `events`, `eras`) for content data alongside the existing `translation` namespace for UI strings. Data hooks in `src/hooks/useData.ts` now merge base JSON with namespace translations via `useTranslation()` + `useMemo`. Full French (fr-FR) and Afrikaans (af-ZA) content translations for all 51 composers, 196 compositions, 47 events, and 6 eras.
 - **Event selection in store** — `selectedEventId` and `selectEvent()` in `useSelectionStore` with mutual exclusion against composition/composer selection.
 - **Data integrity tests** — added 4 test cases to `useData.test.ts` verifying no duplicate composition/composer IDs and that all cross-references between composers and compositions are valid.
 - **i18n infrastructure** — added `react-i18next` with HTTP backend and browser language detection. Translations load from `public/locales/{lng}/translation.json` with `en-GB` fallback. Supported locales: `en-GB`, `fr-FR`, `af-ZA`. Spec at `docs/specs/features/i18n.md`.

--- a/docs/specs/components/ComposerCard.md
+++ b/docs/specs/components/ComposerCard.md
@@ -32,6 +32,10 @@ A detail panel that shows comprehensive information about a selected composer. A
 5. **Historical Context**: Events that happened during this composer's lifetime.
 6. **Actions**: "Focus Timeline" (zooms to lifespan accounting for panel width), "Compare with...", "Explore with AI" (future), "View on Wikipedia".
 
+## Wikipedia Link Localisation
+
+The "View on Wikipedia" link is localised to match the user's current i18n language. The link domain uses the Wikipedia subdomain corresponding to the active language (e.g. `en.wikipedia.org` for English, `fr.wikipedia.org` for French, `af.wikipedia.org` for Afrikaans). The `getWikipediaUrl(slug)` utility in `src/utils/wikipedia.ts` derives the subdomain from `i18next.resolvedLanguage`.
+
 ## Focus Timeline Behavior
 
 The "Focus Timeline" button zooms the main timeline to the composer's lifespan with padding. Because the ComposerCard panel (420px wide) overlaps the right side of the viewport, the zoom accounts for this by adding proportional right-side padding (`rightInsetFraction = panelWidth / viewportWidth`). This ensures the composer's full lifespan is visible in the unobscured area to the left of the panel.

--- a/src/__tests__/CompositionDetail.test.tsx
+++ b/src/__tests__/CompositionDetail.test.tsx
@@ -95,7 +95,7 @@ describe("CompositionDetail", () => {
     expect(wikiLink.getAttribute("rel")).toBe("noopener noreferrer");
     expect(wikiLink.getAttribute("target")).toBe("_blank");
     expect(wikiLink.getAttribute("href")).toContain(
-      `https://en.wikipedia.org/wiki/${compWithWiki.wikipediaSlug}`,
+      `.wikipedia.org/wiki/${compWithWiki.wikipediaSlug}`,
     );
   });
 

--- a/src/components/ComposerCard/ComposerCard.tsx
+++ b/src/components/ComposerCard/ComposerCard.tsx
@@ -9,6 +9,7 @@ import {
   useComposerContemporaries,
 } from "@/hooks/useData";
 import { formatYear } from "@/utils/scales";
+import { getWikipediaUrl } from "@/utils/wikipedia";
 import styles from "./ComposerCard.module.css";
 
 const ERA_COLORS: Record<string, string> = {
@@ -118,7 +119,7 @@ export default function ComposerCard({ composerId }: ComposerCardProps) {
         <h3 className={styles.sectionTitle}>{t("composer.biography")}</h3>
         <p className={styles.biography}>{composer.biography}</p>
         <a
-          href={`https://en.wikipedia.org/wiki/${composer.wikipediaSlug}`}
+          href={getWikipediaUrl(composer.wikipediaSlug)}
           target="_blank"
           rel="noopener noreferrer"
           className={styles.wikiLink}

--- a/src/components/CompositionDetail/CompositionDetail.tsx
+++ b/src/components/CompositionDetail/CompositionDetail.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { useComposition, useComposer } from "@/hooks/useData";
 import { useSelectionStore } from "@/stores/useSelectionStore";
 import { formatYear } from "@/utils/scales";
+import { getWikipediaUrl } from "@/utils/wikipedia";
 import styles from "./CompositionDetail.module.css";
 
 interface CompositionDetailProps {
@@ -90,7 +91,7 @@ export default function CompositionDetail({ compositionId }: CompositionDetailPr
       {/* Wikipedia link */}
       {composition.wikipediaSlug && (
         <a
-          href={`https://en.wikipedia.org/wiki/${composition.wikipediaSlug}`}
+          href={getWikipediaUrl(composition.wikipediaSlug)}
           target="_blank"
           rel="noopener noreferrer"
           className={styles.wikiLink}

--- a/src/components/EventMarker/EventMarker.tsx
+++ b/src/components/EventMarker/EventMarker.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import type { HistoricalEvent } from "@/types";
 import { createTimeScale, formatYear } from "@/utils/scales";
+import { getWikipediaUrl } from "@/utils/wikipedia";
 import styles from "./EventMarker.module.css";
 
 const CATEGORY_COLORS: Record<string, string> = {
@@ -129,7 +130,7 @@ export default function EventMarker({
           </span>
           {event.wikipediaSlug && (
             <a
-              href={`https://en.wikipedia.org/wiki/${event.wikipediaSlug}`}
+              href={getWikipediaUrl(event.wikipediaSlug)}
               target="_blank"
               rel="noopener noreferrer"
               className={styles.wikiLink}

--- a/src/services/WikipediaService.ts
+++ b/src/services/WikipediaService.ts
@@ -1,8 +1,8 @@
 import type { WikiSummary } from "@/types";
+import { getWikipediaApiBase, getWikipediaUrl } from "@/utils/wikipedia";
 
 const CACHE_PREFIX = "wiki:";
 const CACHE_TTL = 24 * 60 * 60 * 1000; // 24 hours
-const API_BASE = "https://en.wikipedia.org/api/rest_v1";
 
 // In-flight request deduplication
 const inflightRequests = new Map<string, Promise<unknown>>();
@@ -72,6 +72,7 @@ export const WikipediaService = {
    * Get a short summary for a Wikipedia article.
    */
   async getSummary(slug: string): Promise<WikiSummary> {
+    const apiBase = getWikipediaApiBase();
     // Check cache first
     const cached = getCached<WikiSummary>(`summary:${slug}`);
     if (cached) return cached;
@@ -79,7 +80,7 @@ export const WikipediaService = {
     return deduplicatedFetch(`summary:${slug}`, async () => {
       try {
         const response = await fetch(
-          `${API_BASE}/page/summary/${encodeURIComponent(slug)}`,
+          `${apiBase}/page/summary/${encodeURIComponent(slug)}`,
         );
         if (!response.ok)
           throw new Error(`Wikipedia API error: ${response.status}`);
@@ -92,7 +93,7 @@ export const WikipediaService = {
           thumbnailUrl: data.thumbnail?.source,
           articleUrl:
             data.content_urls?.desktop?.page ??
-            `https://en.wikipedia.org/wiki/${slug}`,
+            getWikipediaUrl(slug),
         };
 
         setCache(`summary:${slug}`, summary);
@@ -110,13 +111,14 @@ export const WikipediaService = {
    * Get the full article HTML for a Wikipedia article.
    */
   async getArticleHtml(slug: string): Promise<string> {
+    const apiBase = getWikipediaApiBase();
     const cached = getCached<string>(`html:${slug}`);
     if (cached) return cached;
 
     return deduplicatedFetch(`html:${slug}`, async () => {
       try {
         const response = await fetch(
-          `${API_BASE}/page/mobile-html/${encodeURIComponent(slug)}`,
+          `${apiBase}/page/mobile-html/${encodeURIComponent(slug)}`,
         );
         if (!response.ok)
           throw new Error(`Wikipedia API error: ${response.status}`);

--- a/src/utils/wikipedia.ts
+++ b/src/utils/wikipedia.ts
@@ -1,0 +1,26 @@
+import i18n from "i18next";
+
+/**
+ * Derives the Wikipedia language subdomain from the current i18next language.
+ * Maps BCP 47 tags (e.g. "en-GB", "fr-FR") to Wikipedia subdomains ("en", "fr").
+ */
+export function getWikipediaLang(): string {
+  const resolved = i18n.resolvedLanguage ?? i18n.language ?? "en-GB";
+  // Wikipedia subdomains use the primary language subtag
+  return resolved.split("-")[0].toLowerCase();
+}
+
+/**
+ * Builds a Wikipedia article URL for the given slug, localised to the
+ * current i18next language.
+ */
+export function getWikipediaUrl(slug: string): string {
+  return `https://${getWikipediaLang()}.wikipedia.org/wiki/${slug}`;
+}
+
+/**
+ * Returns the Wikipedia REST API base URL for the current language.
+ */
+export function getWikipediaApiBase(): string {
+  return `https://${getWikipediaLang()}.wikipedia.org/api/rest_v1`;
+}


### PR DESCRIPTION
All Wikipedia URLs (ComposerCard, CompositionDetail, EventMarker) and WikipediaService API calls now use the subdomain matching the current i18next language (en/fr/af) instead of hardcoded en.wikipedia.org.

Centralised in src/utils/wikipedia.ts — getWikipediaUrl(), getWikipediaApiBase(), getWikipediaLang().